### PR TITLE
Add React SDK compatibility report and open issue for React 16.8 error

### DIFF
--- a/REACT_COMPATIBILTY_REPORT_JOSHUA.MD
+++ b/REACT_COMPATIBILTY_REPORT_JOSHUA.MD
@@ -1,0 +1,90 @@
+# 🧩 Spotflow React SDK Compatibility Report
+
+## Overview
+This report documents the results of testing the **@spot-flow/react-spotflow-checkout** SDK across multiple React versions as part of **Hacktoberfest**.
+
+The goal was to verify that the SDK installs, renders, and functions properly across React 16.8+, React 17, and React 18.
+
+---
+
+## 🔍 Test Environment
+- **Package tested:** `@spot-flow/react-spotflow-checkout`
+- **Testing mode:** Test key (`sk_test_3500ece212364e11abd01984afdd67b3`)
+- **Build tool:** Vite + React
+- **OS:** Windows 11
+- **Browser:** Chrome
+
+---
+
+## ✅ Compatibility Results
+
+| React Version | Status | Notes |
+|----------------|---------|-------|
+| **16.8** | ❌ **Fail** | Error: `ERR_ABORTED 504 (OUTDATED Optimize Dep)` on import — prevents page re-rendering |
+| **17** | ✅ **Pass** | SDK installs and runs successfully |
+| **18** | ✅ **Pass** | SDK installs and runs successfully |
+
+---
+
+## 🧠 Steps to Reproduce (React 16.8 Failure)
+1. Create a React project using vite:
+   ```bash
+   yarn create 
+   ```
+
+2. downgrade react version to 16.8
+
+3. Install the SDK:
+   ```bash
+   yarn @spot-flow/react-spotflow-checkout
+   ```
+
+4. Import and render the SpotflowButton in App.jsx:
+   ```jsx
+   import { SpotflowButton } from "@spot-flow/react-spotflow-checkout";
+   ```
+
+5. Run the app:
+   ```bash
+   yarn run dev
+   ```
+
+6. Observe the console error.
+
+---
+
+## 🧾 Console Error
+
+```vbnet
+Failed with error ERR_ABORTED 504 (OUTDATED Optimize Dep)
+```
+
+---
+
+## Expected Behaviour
+The SDK should install and render successfully across all React versions starting from 16.8+, as stated in documentation.
+
+---
+
+## Proposed Solution
+- Investigate SDK dependencies that may rely on newer React APIs or build systems incompatible with React 16.8.
+
+- Consider updating the documentation to specify the minimum supported React version (v17+) if backward compatibility is not intended.
+
+- Optionally, provide a compatibility shim or separate legacy build.
+
+## 🔗 Related Resources
+
+- [Spotflow Docs](https://docs.spotflow.one/)
+
+- [NPM Package](https://www.npmjs.com/package/@spot-flow/react-spotflow-checkout)
+
+- Related Issue: #20
+
+---
+
+Author: Joshua
+
+Date: October 2025
+
+Hacktoberfest Contribution


### PR DESCRIPTION
# What does this PR do?

This PR documents the compatibility testing results of the **@spot-flow/react-spotflow-checkout** SDK across multiple React versions (16.8, 17, and 18) as part of Hacktoberfest 2025.

It includes a Markdown report file summarizing the findings and links to a separate issue detailing the React 16.8 compatibility failure.

---

## Description of Task

- Tested the Spotflow React SDK on React 16.8, React 17, and React 18.
- Documented the results in a report file: 
  `REACT_COMPATIBILITY_REPORT_JOSHUA.MD`
- Created a new issue describing the React 16.8 import error (`ERR_ABORTED 504`).
- Suggested potential causes and next steps for compatibility or documentation updates.

---

## How should this be manually tested?

1. Open the Markdown report file: 
   `REACT_COMPATIBILITY_REPORT_JOSHUA.MD`
2. Review the table of React versions and results.
3. Follow the reproduction steps in the report to recreate the React 16.8 error:
   - Create a new React 16.8 project
   - Install `@spot-flow/react-spotflow-checkout`
   - Import and render the component
   - Observe the browser console for `ERR_ABORTED 504 (OUTDATED Optimize Dep)` error

---

## Screenshots/Screen records
<img width="3832" height="1818" alt="spotflow-react-16 8" src="https://github.com/user-attachments/assets/c0d076d0-c3a7-4a73-bd77-1167e1733276" />


## Link to Issue
#20

## Background Context

- React 16.8 introduces Hooks but uses older build tools, which might not be compatible with newer SDK dependencies.
- React 17 and 18 function correctly, suggesting minimum support may start from React 17.
